### PR TITLE
ElastAlert / Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:2.7-slim
+
+RUN echo 'Acquire::Retires "10";' > /etc/apt/apt.conf.d/50aptgetretries
+
+RUN mkdir /elastalert
+COPY . /elastalert
+
+RUN apt-get update && apt-get upgrade -y
+
+RUN apt-get install -y python2.7-dev gcc git
+
+RUN pip2 install -r /elastalert/requirements.txt
+
+RUN cd /elastalert && \
+  python setup.py install
+
+CMD python /elastalert/elastalert/elastalert.py --config /elastalert/config.yaml


### PR DESCRIPTION
- Based on dockerfile_tmp, installs and runs ElastAlert
- Everything gets copied to /elastalert, allowing for a config file
  to be added during run time.
