### PR TITLE
Fix: Change CMD format, add verbose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN pip2 install -r /elastalert/requirements.txt
 RUN cd /elastalert && \
   python setup.py install
 
-CMD python /elastalert/elastalert/elastalert.py --config /elastalert/config.yaml
+CMD ["python","/elastalert/elastalert/elastalert.py","--config","/elastalert/config.yaml","--verbose"]


### PR DESCRIPTION
Fixed the CMD format to use exec rather than running within a shell, this will allow us to send a SIGTERM instead of a straight killing the container, which is happening currently.

Added `--verbose` to the command line, so we can see what exactly Elastalert is doing